### PR TITLE
feat: Add RTC service with REST API and WebSocket signaling

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"github.com/PocketPalCo/shopping-service/config"
+	"github.com/PocketPalCo/shopping-service/internal/core/rtc" // Added import for rtc package
 	"github.com/PocketPalCo/shopping-service/internal/infra/postgres"
 	"github.com/PocketPalCo/shopping-service/internal/infra/server"
 	"github.com/PocketPalCo/shopping-service/pkg/logger"
@@ -29,7 +30,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	mainServer := server.New(ctx, &cfg, conn)
+	rtcService := rtc.NewRTCService() // Create RTCService instance
+
+	mainServer := server.New(ctx, &cfg, conn, rtcService) // Pass rtcService to server.New
 	go mainServer.Start()
 
 	interrupt := make(chan os.Signal, 1)

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -14,7 +14,273 @@ const docTemplate = `{
     },
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
-    "paths": {}
+    "paths": {
+        "/v1/rtc/room": {
+            "post": {
+                "description": "Creates a new RTC room. A room ID can be provided, or one will be generated.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rtc"
+                ],
+                "summary": "Create a new RTC room",
+                "parameters": [
+                    {
+                        "description": "Room creation details",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/rest.CreateRoomRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Room created successfully",
+                        "schema": {
+                            "$ref": "#/definitions/rest.CreateRoomResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - Invalid input",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/rtc/room/{roomId}": {
+            "get": {
+                "description": "Retrieves the details of a specific RTC room, including the list of users.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rtc"
+                ],
+                "summary": "Get RTC room details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Room ID",
+                        "name": "roomId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Room details retrieved successfully",
+                        "schema": {
+                            "$ref": "#/definitions/rest.GetRoomResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - Room not found",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/rtc/room/{roomId}/join": {
+            "post": {
+                "description": "Allows a user to join an existing RTC room.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rtc"
+                ],
+                "summary": "Join an RTC room",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Room ID",
+                        "name": "roomId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "User ID to join the room",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/rest.JoinLeaveRoomRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User joined successfully",
+                        "schema": {
+                            "$ref": "#/definitions/rest.SuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - Invalid input or user ID missing",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - Room not found",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error - Could not join room",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/rtc/room/{roomId}/leave": {
+            "post": {
+                "description": "Allows a user to leave an RTC room.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rtc"
+                ],
+                "summary": "Leave an RTC room",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Room ID",
+                        "name": "roomId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "User ID to leave the room",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/rest.JoinLeaveRoomRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User left successfully",
+                        "schema": {
+                            "$ref": "#/definitions/rest.SuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - Invalid input or user ID missing",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - Room or user not found",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error - Could not leave room",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "rest.CreateRoomRequest": {
+            "type": "object",
+            "properties": {
+                "room_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "rest.CreateRoomResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "users": {
+                    "description": "Number of users in the room",
+                    "type": "integer"
+                }
+            }
+        },
+        "rest.ErrorResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                }
+            }
+        },
+        "rest.GetRoomResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "users": {
+                    "description": "List of user IDs in the room",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "rest.JoinLeaveRoomRequest": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "rest.SuccessResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        }
+    }
 }`
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3,5 +3,271 @@
     "info": {
         "contact": {}
     },
-    "paths": {}
+    "paths": {
+        "/v1/rtc/room": {
+            "post": {
+                "description": "Creates a new RTC room. A room ID can be provided, or one will be generated.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rtc"
+                ],
+                "summary": "Create a new RTC room",
+                "parameters": [
+                    {
+                        "description": "Room creation details",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/rest.CreateRoomRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Room created successfully",
+                        "schema": {
+                            "$ref": "#/definitions/rest.CreateRoomResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - Invalid input",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/rtc/room/{roomId}": {
+            "get": {
+                "description": "Retrieves the details of a specific RTC room, including the list of users.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rtc"
+                ],
+                "summary": "Get RTC room details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Room ID",
+                        "name": "roomId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Room details retrieved successfully",
+                        "schema": {
+                            "$ref": "#/definitions/rest.GetRoomResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - Room not found",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/rtc/room/{roomId}/join": {
+            "post": {
+                "description": "Allows a user to join an existing RTC room.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rtc"
+                ],
+                "summary": "Join an RTC room",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Room ID",
+                        "name": "roomId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "User ID to join the room",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/rest.JoinLeaveRoomRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User joined successfully",
+                        "schema": {
+                            "$ref": "#/definitions/rest.SuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - Invalid input or user ID missing",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - Room not found",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error - Could not join room",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/rtc/room/{roomId}/leave": {
+            "post": {
+                "description": "Allows a user to leave an RTC room.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rtc"
+                ],
+                "summary": "Leave an RTC room",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Room ID",
+                        "name": "roomId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "User ID to leave the room",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/rest.JoinLeaveRoomRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User left successfully",
+                        "schema": {
+                            "$ref": "#/definitions/rest.SuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - Invalid input or user ID missing",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - Room or user not found",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error - Could not leave room",
+                        "schema": {
+                            "$ref": "#/definitions/rest.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "rest.CreateRoomRequest": {
+            "type": "object",
+            "properties": {
+                "room_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "rest.CreateRoomResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "users": {
+                    "description": "Number of users in the room",
+                    "type": "integer"
+                }
+            }
+        },
+        "rest.ErrorResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                }
+            }
+        },
+        "rest.GetRoomResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "users": {
+                    "description": "List of user IDs in the room",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "rest.JoinLeaveRoomRequest": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "rest.SuccessResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        }
+    }
 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,4 +1,179 @@
+definitions:
+  rest.CreateRoomRequest:
+    properties:
+      room_id:
+        type: string
+    type: object
+  rest.CreateRoomResponse:
+    properties:
+      id:
+        type: string
+      users:
+        description: Number of users in the room
+        type: integer
+    type: object
+  rest.ErrorResponse:
+    properties:
+      error:
+        type: string
+    type: object
+  rest.GetRoomResponse:
+    properties:
+      id:
+        type: string
+      users:
+        description: List of user IDs in the room
+        items:
+          type: string
+        type: array
+    type: object
+  rest.JoinLeaveRoomRequest:
+    properties:
+      user_id:
+        type: string
+    type: object
+  rest.SuccessResponse:
+    properties:
+      message:
+        type: string
+    type: object
 info:
   contact: {}
-paths: {}
+paths:
+  /v1/rtc/room:
+    post:
+      consumes:
+      - application/json
+      description: Creates a new RTC room. A room ID can be provided, or one will
+        be generated.
+      parameters:
+      - description: Room creation details
+        in: body
+        name: body
+        schema:
+          $ref: '#/definitions/rest.CreateRoomRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Room created successfully
+          schema:
+            $ref: '#/definitions/rest.CreateRoomResponse'
+        "400":
+          description: Bad Request - Invalid input
+          schema:
+            $ref: '#/definitions/rest.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rest.ErrorResponse'
+      summary: Create a new RTC room
+      tags:
+      - rtc
+  /v1/rtc/room/{roomId}:
+    get:
+      description: Retrieves the details of a specific RTC room, including the list
+        of users.
+      parameters:
+      - description: Room ID
+        in: path
+        name: roomId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Room details retrieved successfully
+          schema:
+            $ref: '#/definitions/rest.GetRoomResponse'
+        "404":
+          description: Not Found - Room not found
+          schema:
+            $ref: '#/definitions/rest.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/rest.ErrorResponse'
+      summary: Get RTC room details
+      tags:
+      - rtc
+  /v1/rtc/room/{roomId}/join:
+    post:
+      consumes:
+      - application/json
+      description: Allows a user to join an existing RTC room.
+      parameters:
+      - description: Room ID
+        in: path
+        name: roomId
+        required: true
+        type: string
+      - description: User ID to join the room
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/rest.JoinLeaveRoomRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: User joined successfully
+          schema:
+            $ref: '#/definitions/rest.SuccessResponse'
+        "400":
+          description: Bad Request - Invalid input or user ID missing
+          schema:
+            $ref: '#/definitions/rest.ErrorResponse'
+        "404":
+          description: Not Found - Room not found
+          schema:
+            $ref: '#/definitions/rest.ErrorResponse'
+        "500":
+          description: Internal Server Error - Could not join room
+          schema:
+            $ref: '#/definitions/rest.ErrorResponse'
+      summary: Join an RTC room
+      tags:
+      - rtc
+  /v1/rtc/room/{roomId}/leave:
+    post:
+      consumes:
+      - application/json
+      description: Allows a user to leave an RTC room.
+      parameters:
+      - description: Room ID
+        in: path
+        name: roomId
+        required: true
+        type: string
+      - description: User ID to leave the room
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/rest.JoinLeaveRoomRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: User left successfully
+          schema:
+            $ref: '#/definitions/rest.SuccessResponse'
+        "400":
+          description: Bad Request - Invalid input or user ID missing
+          schema:
+            $ref: '#/definitions/rest.ErrorResponse'
+        "404":
+          description: Not Found - Room or user not found
+          schema:
+            $ref: '#/definitions/rest.ErrorResponse'
+        "500":
+          description: Internal Server Error - Could not leave room
+          schema:
+            $ref: '#/definitions/rest.ErrorResponse'
+      summary: Leave an RTC room
+      tags:
+      - rtc
 swagger: "2.0"

--- a/internal/core/rtc/rtc_service.go
+++ b/internal/core/rtc/rtc_service.go
@@ -1,0 +1,145 @@
+// Package rtc handles the core Real-Time Communication logic.
+package rtc
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/gofiber/contrib/websocket"
+)
+
+// Room represents a communication room.
+type Room struct {
+	ID    string
+	Users map[string]*User
+}
+
+// User represents a user in a room.
+type User struct {
+	ID   string
+	Conn *websocket.Conn
+}
+
+// RTCService manages rooms and users.
+type RTCService struct {
+	Rooms map[string]*Room
+	mu    sync.RWMutex
+}
+
+// NewRTCService creates a new RTCService.
+func NewRTCService() *RTCService {
+	return &RTCService{
+		Rooms: make(map[string]*Room),
+	}
+}
+
+// CreateRoom creates a new room with the given ID.
+func (s *RTCService) CreateRoom(roomID string) (*Room, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.Rooms[roomID]; exists {
+		return nil, fmt.Errorf("room %s already exists", roomID)
+	}
+
+	room := &Room{
+		ID:    roomID,
+		Users: make(map[string]*User),
+	}
+	s.Rooms[roomID] = room
+	return room, nil
+}
+
+// JoinRoom adds a user to a room.
+func (s *RTCService) JoinRoom(roomID string, userID string, conn *websocket.Conn) (*Room, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	room, exists := s.Rooms[roomID]
+	if !exists {
+		return nil, fmt.Errorf("room %s not found", roomID)
+	}
+
+	if _, userExists := room.Users[userID]; userExists {
+		return nil, fmt.Errorf("user %s already in room %s", userID, roomID)
+	}
+
+	user := &User{
+		ID:   userID,
+		Conn: conn,
+	}
+	room.Users[userID] = user
+	return room, nil
+}
+
+// LeaveRoom removes a user from a room.
+func (s *RTCService) LeaveRoom(roomID string, userID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	room, exists := s.Rooms[roomID]
+	if !exists {
+		return fmt.Errorf("room %s not found", roomID)
+	}
+
+	if _, userExists := room.Users[userID]; !userExists {
+		return fmt.Errorf("user %s not in room %s", userID, roomID)
+	}
+
+	delete(room.Users, userID)
+	return nil
+}
+
+// GetRoom retrieves a room by its ID.
+func (s *RTCService) GetRoom(roomID string) (*Room, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	room, exists := s.Rooms[roomID]
+	if !exists {
+		return nil, fmt.Errorf("room %s not found", roomID)
+	}
+	return room, nil
+}
+
+// SignalMessage sends a signal message to users in a room (excluding the sender).
+// For now, it just logs the action.
+func (s *RTCService) SignalMessage(roomID string, senderID string, message []byte) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	room, exists := s.Rooms[roomID]
+	if !exists {
+		return fmt.Errorf("room %s not found", roomID)
+	}
+
+	fmt.Printf("SignalMessage: Room=%s, Sender=%s, MessageLength=%d\n", roomID, senderID, len(message))
+
+	var sendErrors []error
+	for userID, user := range room.Users {
+		if userID != senderID { // Do not send the message back to the sender
+			if user.Conn != nil {
+				// It's important to handle errors here, e.g., by logging or removing dead connections.
+				// For simplicity in this example, we'll collect errors.
+				// Note: WriteMessage is not concurrency-safe for multiple goroutines writing to the same Conn.
+				// However, each user has their own Conn, and this loop is synchronous for writes to different Conns.
+				// If SignalMessage itself could be called concurrently for the *same user*, User.Conn access would need a mutex.
+				// But here, s.mu.RLock() protects Rooms map, and each user.Conn is distinct.
+				if err := user.Conn.WriteMessage(websocket.TextMessage, message); err != nil {
+					sendErrors = append(sendErrors, fmt.Errorf("failed to send message to user %s in room %s: %w", userID, roomID, err))
+					// TODO: Consider removing user or marking connection as stale if WriteMessage fails.
+					// For example:
+					// go s.LeaveRoom(roomID, userID) // This would need its own error handling and careful locking.
+				}
+			}
+		}
+	}
+
+	if len(sendErrors) > 0 {
+		// For now, just return the first error, or a summary.
+		// In a real app, you might log all errors.
+		return fmt.Errorf("errors during SignalMessage broadcast: %v", sendErrors)
+	}
+
+	return nil
+}

--- a/internal/core/rtc/rtc_service_test.go
+++ b/internal/core/rtc/rtc_service_test.go
@@ -1,0 +1,432 @@
+// Package rtc_test contains unit tests for the rtc package.
+package rtc_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PocketPalCo/shopping-service/internal/core/rtc"
+	"github.com/gofiber/contrib/websocket" // Import for User.Conn, though direct testing is hard
+)
+
+// Helper function to create a mock websocket.Conn for testing.
+// Note: This is a very basic mock. In a real scenario, you might need a more sophisticated mock
+// or to refactor RTCService to use an interface for connections to make testing easier.
+func newMockConn() *websocket.Conn {
+	// For the purpose of these unit tests, we don't need a fully functional connection.
+	// We only need to check if the pointer is stored and retrieved correctly.
+	// In a real application, you might not be able to instantiate websocket.Conn directly
+	// or might need to use a library that provides mock WebSocket connections.
+	// However, since User.Conn is a direct struct pointer, we pass nil for now,
+	// as the service logic doesn't dereference it in a way that would panic in these tests.
+	// If it did, we'd need a more complex setup or a refactor.
+	return nil
+}
+
+// TestNewRTCService tests the NewRTCService function.
+func TestNewRTCService(t *testing.T) {
+	service := rtc.NewRTCService()
+	if service == nil {
+		t.Fatal("NewRTCService() returned nil")
+	}
+	if service.Rooms == nil {
+		t.Error("NewRTCService() Rooms map is nil")
+	}
+	if len(service.Rooms) != 0 {
+		t.Errorf("NewRTCService() Rooms map is not empty, got %d, want %d", len(service.Rooms), 0)
+	}
+}
+
+// TestCreateRoom tests the CreateRoom method.
+func TestCreateRoom(t *testing.T) {
+	service := rtc.NewRTCService()
+	roomID := "test-room-1"
+
+	// Test successful room creation
+	room, err := service.CreateRoom(roomID)
+	if err != nil {
+		t.Fatalf("CreateRoom() with new ID failed: %v", err)
+	}
+	if room == nil {
+		t.Fatal("CreateRoom() returned nil room on success")
+	}
+	if room.ID != roomID {
+		t.Errorf("CreateRoom() room ID got %s, want %s", room.ID, roomID)
+	}
+	if len(room.Users) != 0 {
+		t.Errorf("CreateRoom() new room Users map is not empty, got %d, want %d", len(room.Users), 0)
+	}
+
+	// Verify room is in service.Rooms
+	_, ok := service.Rooms[roomID]
+	if !ok {
+		t.Errorf("CreateRoom() room %s not found in service.Rooms after creation", roomID)
+	}
+
+	// Test creating a room that already exists
+	_, err = service.CreateRoom(roomID)
+	if err == nil {
+		t.Errorf("CreateRoom() with existing ID expected error, got nil")
+	}
+	expectedErr := fmt.Sprintf("room %s already exists", roomID)
+	if err != nil && err.Error() != expectedErr {
+		t.Errorf("CreateRoom() with existing ID error got '%v', want '%s'", err, expectedErr)
+	}
+}
+
+// TestGetRoom tests the GetRoom method.
+func TestGetRoom(t *testing.T) {
+	service := rtc.NewRTCService()
+	roomID := "test-room-get"
+
+	// Test getting a non-existent room
+	_, err := service.GetRoom(roomID)
+	if err == nil {
+		t.Errorf("GetRoom() with non-existent ID expected error, got nil")
+	}
+	expectedErr := fmt.Sprintf("room %s not found", roomID)
+	if err != nil && err.Error() != expectedErr {
+		t.Errorf("GetRoom() with non-existent ID error got '%v', want '%s'", err, expectedErr)
+	}
+
+	// Create a room
+	createdRoom, _ := service.CreateRoom(roomID)
+
+	// Test getting an existing room
+	retrievedRoom, err := service.GetRoom(roomID)
+	if err != nil {
+		t.Fatalf("GetRoom() with existing ID failed: %v", err)
+	}
+	if retrievedRoom == nil {
+		t.Fatal("GetRoom() returned nil for existing room")
+	}
+	if retrievedRoom.ID != roomID {
+		t.Errorf("GetRoom() room ID got %s, want %s", retrievedRoom.ID, roomID)
+	}
+	if retrievedRoom != createdRoom { // Check if it's the same instance
+		t.Error("GetRoom() returned a different room instance than expected")
+	}
+}
+
+// TestJoinRoom tests the JoinRoom method.
+func TestJoinRoom(t *testing.T) {
+	service := rtc.NewRTCService()
+	roomID := "test-room-join"
+	userID1 := "user1"
+	userID2 := "user2"
+	mockConn1 := newMockConn()
+	mockConn2 := newMockConn()
+
+	// Test joining a non-existent room
+	_, err := service.JoinRoom(roomID, userID1, mockConn1)
+	if err == nil {
+		t.Errorf("JoinRoom() to non-existent room expected error, got nil")
+	}
+	expectedErrNonExistent := fmt.Sprintf("room %s not found", roomID)
+	if err != nil && err.Error() != expectedErrNonExistent {
+		t.Errorf("JoinRoom() to non-existent room error got '%v', want '%s'", err, expectedErrNonExistent)
+	}
+
+	// Create a room first
+	_, _ = service.CreateRoom(roomID)
+
+	// Test successfully joining an existing room
+	room, err := service.JoinRoom(roomID, userID1, mockConn1)
+	if err != nil {
+		t.Fatalf("JoinRoom() failed for user1: %v", err)
+	}
+	if room == nil {
+		t.Fatal("JoinRoom() returned nil room on successful join for user1")
+	}
+	if len(room.Users) != 1 {
+		t.Errorf("JoinRoom() user1, room user count got %d, want %d", len(room.Users), 1)
+	}
+	user1InRoom, ok := room.Users[userID1]
+	if !ok {
+		t.Fatalf("JoinRoom() user1 not found in room.Users map")
+	}
+	if user1InRoom.ID != userID1 {
+		t.Errorf("JoinRoom() user1 ID in room got %s, want %s", user1InRoom.ID, userID1)
+	}
+	if user1InRoom.Conn != mockConn1 {
+		t.Errorf("JoinRoom() user1 Conn in room not stored correctly")
+	}
+
+	// Test another user joining the same room
+	room, err = service.JoinRoom(roomID, userID2, mockConn2)
+	if err != nil {
+		t.Fatalf("JoinRoom() failed for user2: %v", err)
+	}
+	if len(room.Users) != 2 {
+		t.Errorf("JoinRoom() user2, room user count got %d, want %d", len(room.Users), 2)
+	}
+	user2InRoom, ok := room.Users[userID2]
+	if !ok {
+		t.Fatalf("JoinRoom() user2 not found in room.Users map")
+	}
+	if user2InRoom.ID != userID2 {
+		t.Errorf("JoinRoom() user2 ID in room got %s, want %s", user2InRoom.ID, userID2)
+	}
+	if user2InRoom.Conn != mockConn2 {
+		t.Errorf("JoinRoom() user2 Conn in room not stored correctly")
+	}
+
+	// Test a user joining a room they are already in
+	_, err = service.JoinRoom(roomID, userID1, mockConn1) // User1 tries to join again
+	if err == nil {
+		t.Errorf("JoinRoom() with already joined user expected error, got nil")
+	}
+	expectedErrExistingUser := fmt.Sprintf("user %s already in room %s", userID1, roomID)
+	if err != nil && err.Error() != expectedErrExistingUser {
+		t.Errorf("JoinRoom() with already joined user error got '%v', want '%s'", err, expectedErrExistingUser)
+	}
+	if len(room.Users) != 2 { // Ensure user count hasn't changed
+		t.Errorf("JoinRoom() user count changed after attempt to re-join, got %d, want %d", len(room.Users), 2)
+	}
+}
+
+// TestLeaveRoom tests the LeaveRoom method.
+func TestLeaveRoom(t *testing.T) {
+	service := rtc.NewRTCService()
+	roomID := "test-room-leave"
+	userID1 := "user1"
+	userID2 := "user2" // Another user to ensure room is not deleted prematurely
+	mockConn1 := newMockConn()
+	mockConn2 := newMockConn()
+
+	// Test leaving a non-existent room
+	err := service.LeaveRoom(roomID, userID1)
+	if err == nil {
+		t.Errorf("LeaveRoom() from non-existent room expected error, got nil")
+	}
+	expectedErrNonExistent := fmt.Sprintf("room %s not found", roomID)
+	if err != nil && err.Error() != expectedErrNonExistent {
+		t.Errorf("LeaveRoom() from non-existent room error got '%v', want '%s'", err, expectedErrNonExistent)
+	}
+
+	// Create room and add users
+	_, _ = service.CreateRoom(roomID)
+	_, _ = service.JoinRoom(roomID, userID1, mockConn1)
+	_, _ = service.JoinRoom(roomID, userID2, mockConn2)
+
+	// Test a user leaving a room they are not in (but room exists)
+	nonExistentUserID := "ghost-user"
+	err = service.LeaveRoom(roomID, nonExistentUserID)
+	if err == nil {
+		t.Errorf("LeaveRoom() for user not in room expected error, got nil")
+	}
+	expectedErrUserNotFound := fmt.Sprintf("user %s not in room %s", nonExistentUserID, roomID)
+	if err != nil && err.Error() != expectedErrUserNotFound {
+		t.Errorf("LeaveRoom() for user not in room error got '%v', want '%s'", err, expectedErrUserNotFound)
+	}
+
+	// Test a user successfully leaving a room
+	err = service.LeaveRoom(roomID, userID1)
+	if err != nil {
+		t.Fatalf("LeaveRoom() for user1 failed: %v", err)
+	}
+
+	// Verify user1 is removed
+	room, _ := service.GetRoom(roomID)
+	if _, ok := room.Users[userID1]; ok {
+		t.Errorf("LeaveRoom() user1 still found in room.Users after leaving")
+	}
+	if len(room.Users) != 1 {
+		t.Errorf("LeaveRoom() room user count got %d, want %d after user1 left", len(room.Users), 1)
+	}
+	// Verify user2 is still there
+	if _, ok := room.Users[userID2]; !ok {
+		t.Errorf("LeaveRoom() user2 was unexpectedly removed after user1 left")
+	}
+
+	// Test the same user trying to leave again (now they are not in the room)
+	err = service.LeaveRoom(roomID, userID1)
+	if err == nil {
+		t.Errorf("LeaveRoom() for user1 again (should not be in room) expected error, got nil")
+	}
+	expectedErrUser1NotInRoom := fmt.Sprintf("user %s not in room %s", userID1, roomID)
+	if err != nil && err.Error() != expectedErrUser1NotInRoom {
+		t.Errorf("LeaveRoom() for user1 again error got '%v', want '%s'", err, expectedErrUser1NotInRoom)
+	}
+}
+
+// TestSignalMessage tests the SignalMessage method (basic functionality).
+// This test primarily checks that the method doesn't panic and attempts to access users.
+// It does not verify actual message sending over WebSockets.
+func TestSignalMessage(t *testing.T) {
+	service := rtc.NewRTCService()
+	roomID := "test-room-signal"
+	senderID := "senderUser"
+	receiverID := "receiverUser"
+	mockConnSender := newMockConn()
+	mockConnReceiver := newMockConn() // In a real scenario, this would receive the message
+
+	// Test signaling in a non-existent room
+	err := service.SignalMessage(roomID, senderID, []byte("hello"))
+	if err == nil {
+		t.Errorf("SignalMessage() in non-existent room expected error, got nil")
+	}
+	expectedErrNonExistent := fmt.Sprintf("room %s not found", roomID)
+	if err != nil && err.Error() != expectedErrNonExistent {
+		t.Errorf("SignalMessage() in non-existent room error got '%v', want '%s'", err, expectedErrNonExistent)
+	}
+
+	// Create room and add users
+	_, _ = service.CreateRoom(roomID)
+	_, _ = service.JoinRoom(roomID, senderID, mockConnSender)
+	_, _ = service.JoinRoom(roomID, receiverID, mockConnReceiver)
+
+	// Test successful signal (no panic, no error returned by current implementation)
+	// The current SignalMessage just logs and doesn't send, so no error is expected.
+	// This test ensures it runs without issues.
+	err = service.SignalMessage(roomID, senderID, []byte("hello"))
+	if err != nil {
+		t.Fatalf("SignalMessage() failed: %v", err)
+	}
+
+	// Test signaling from a user not in the room (though room exists)
+	// RTCService.SignalMessage doesn't currently check if senderID is in the room's user list.
+	// It only checks if the room exists. This behavior could be a point of discussion.
+	// For now, this should not return an error as long as the room exists.
+	err = service.SignalMessage(roomID, "nonExistentSender", []byte("test"))
+	if err != nil {
+		t.Fatalf("SignalMessage() from non-existent sender failed: %v", err)
+	}
+
+	// Test signaling with an empty message
+	err = service.SignalMessage(roomID, senderID, []byte(""))
+	if err != nil {
+		t.Fatalf("SignalMessage() with empty message failed: %v", err)
+	}
+
+	// Test signaling in a room with only one user (the sender)
+	singleUserRoomID := "single-user-room"
+	singleUserID := "singleUser"
+	_, _ = service.CreateRoom(singleUserRoomID)
+	_, _ = service.JoinRoom(singleUserRoomID, singleUserID, newMockConn())
+	err = service.SignalMessage(singleUserRoomID, singleUserID, []byte("lonely signal"))
+	if err != nil {
+		t.Fatalf("SignalMessage() in single-user room failed: %v", err)
+	}
+	// If SignalMessage had a way to count recipients, we'd check it's 0 here.
+	// For now, just ensure no error/panic.
+}
+
+// Add more advanced tests for SignalMessage if User struct or RTCService is refactored for testability,
+// e.g., by adding a mockable sender interface or a way to inspect outgoing messages.
+// For example, if User had a field like `LastMessageReceived []byte` (for testing only):
+/*
+func TestSignalMessage_VerifyMessageDelivery(t *testing.T) {
+	service := rtc.NewRTCService()
+	roomID := "test-room-signal-delivery"
+	senderID := "sender"
+	receiverID1 := "receiver1"
+	receiverID2 := "receiver2"
+
+	// Mock connections - in a real test with interfaces, these would be mocks
+	// that allow inspecting sent data.
+	mockConnSender := newMockConn()
+	mockConnReceiver1 := newMockConn() // This would be a mock that can "receive" a message
+	mockConnReceiver2 := newMockConn() // Same here
+
+	_, _ = service.CreateRoom(roomID)
+	room, _ := service.GetRoom(roomID)
+
+	// For this hypothetical test, assume User struct is modified for testing:
+	// type User struct {
+	// 	ID   string
+	// 	Conn *websocket.Conn
+	// 	LastMessageReceived []byte // TESTING ONLY
+	// }
+	// And RTCService.SignalMessage is modified to populate this field (again, for testing).
+
+	userSender := &rtc.User{ID: senderID, Conn: mockConnSender}
+	userReceiver1 := &rtc.User{ID: receiverID1, Conn: mockConnReceiver1}
+	userReceiver2 := &rtc.User{ID: receiverID2, Conn: mockConnReceiver2}
+
+	room.Users[senderID] = userSender
+	room.Users[receiverID1] = userReceiver1
+	room.Users[receiverID2] = userReceiver2
+
+	message := []byte("super secret signal")
+	err := service.SignalMessage(roomID, senderID, message)
+	if err != nil {
+		t.Fatalf("SignalMessage() failed: %v", err)
+	}
+
+	// Assert that receiver1 got the message and sender/receiver2 (if sender was also a receiver) did not
+	// This requires RTCService.SignalMessage to be modified to use user.Conn.WriteMessage
+	// and for the mockConn to record what was written.
+	// if !bytes.Equal(userReceiver1.LastMessageReceived, message) {
+	// 	t.Errorf("Receiver1 did not receive the correct message. Got %s, want %s", userReceiver1.LastMessageReceived, message)
+	// }
+	// if userSender.LastMessageReceived != nil {
+	// 	t.Errorf("Sender should not have received their own message. Got %s", userSender.LastMessageReceived)
+	// }
+
+	// This part is highly dependent on how message sending is implemented and mocked.
+	// The current rtc_service.go does not actually send, so this test cannot be fully realized yet.
+	t.Log("TestSignalMessage_VerifyMessageDelivery is a placeholder for more advanced testing if service is refactored.")
+}
+*/
+
+// Note on websocket.Conn:
+// The `websocket.Conn` from `github.com/gofiber/contrib/websocket` is a concrete struct.
+// True unit testing of message sending would require either:
+// 1. An interface for the connection that can be mocked (e.g., `type MessageSender interface { WriteMessage(int, []byte) error }`).
+//    RTCService and User would use this interface.
+// 2. Running a real WebSocket server and client within the test, which leans towards integration testing.
+// 3. Modifying User struct for tests to include a channel or callback that SignalMessage uses.
+// For these unit tests, we focus on the state management logic of RTCService.
+// The actual `SignalMessage` implementation in `rtc_service.go` currently only logs and doesn't send,
+// so these tests verify it runs without error.
+// The placeholder `TestSignalMessage_VerifyMessageDelivery` illustrates how one might test further.
+
+func ExampleRTCService_CreateRoom() {
+	service := rtc.NewRTCService()
+	room, err := service.CreateRoom("example-room")
+	if err != nil {
+		fmt.Printf("Error creating room: %v\n", err)
+		return
+	}
+	fmt.Printf("Room created: %s, Users: %d\n", room.ID, len(room.Users))
+
+	// Try to create it again
+	_, err = service.CreateRoom("example-room")
+	if err != nil {
+		fmt.Printf("Error creating room again: %v\n", err)
+	}
+	// Output:
+	// Room created: example-room, Users: 0
+	// Error creating room again: room example-room already exists
+}
+
+func ExampleRTCService_JoinRoom() {
+	service := rtc.NewRTCService()
+	roomID := "chat-room-101"
+	userID := "alice"
+
+	// Attempt to join before room exists
+	_, err := service.JoinRoom(roomID, userID, nil) // Using nil for mock conn
+	if err != nil {
+		fmt.Printf("Error joining non-existent room: %v\n", err)
+	}
+
+	_, _ = service.CreateRoom(roomID)
+	room, err := service.JoinRoom(roomID, userID, nil)
+	if err != nil {
+		fmt.Printf("Error joining room: %v\n", err)
+		return
+	}
+	fmt.Printf("User %s joined room %s. Total users: %d\n", userID, room.ID, len(room.Users))
+
+	// Attempt to join again
+	_, err = service.JoinRoom(roomID, userID, nil)
+	if err != nil {
+		fmt.Printf("Error joining room again: %v\n", err)
+	}
+	// Output:
+	// Error joining non-existent room: room chat-room-101 not found
+	// User alice joined room chat-room-101. Total users: 1
+	// Error joining room again: user alice already in room chat-room-101
+}

--- a/internal/infra/rest/rtc_routes.go
+++ b/internal/infra/rest/rtc_routes.go
@@ -1,0 +1,222 @@
+// Package rest handles the REST API endpoints.
+package rest
+
+import (
+	"fmt"
+	"log" // Added for logging errors
+
+	"github.com/PocketPalCo/shopping-service/config" // Import main config
+	"github.com/PocketPalCo/shopping-service/internal/core/rtc"
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid" // For generating room IDs
+)
+
+// CreateRoomRequest defines the expected request body for creating a room.
+type CreateRoomRequest struct {
+	RoomID string `json:"room_id"`
+}
+
+// CreateRoomResponse defines the response body for creating a room.
+type CreateRoomResponse struct {
+	ID    string `json:"id"`
+	Users int    `json:"users"` // Number of users in the room
+}
+
+// JoinLeaveRoomRequest defines the expected request body for joining or leaving a room.
+type JoinLeaveRoomRequest struct {
+	UserID string `json:"user_id"`
+}
+
+// ErrorResponse defines a standard error response.
+type ErrorResponse struct {
+	Error string `json:"error"`
+}
+
+// SuccessResponse defines a standard success response.
+type SuccessResponse struct {
+	Message string `json:"message"`
+}
+
+// GetRoomResponse defines the response for getting room details.
+type GetRoomResponse struct {
+	ID    string   `json:"id"`
+	Users []string `json:"users"` // List of user IDs in the room
+}
+
+// CreateRoomHandler handles the creation of a new room.
+// @Summary Create a new RTC room
+// @Description Creates a new RTC room. A room ID can be provided, or one will be generated.
+// @Tags rtc
+// @Accept json
+// @Produce json
+// @Param body body CreateRoomRequest false "Room creation details"
+// @Success 201 {object} CreateRoomResponse "Room created successfully"
+// @Failure 400 {object} ErrorResponse "Bad Request - Invalid input"
+// @Failure 500 {object} ErrorResponse "Internal Server Error"
+// @Router /v1/rtc/room [post]
+func CreateRoomHandler(rtcService *rtc.RTCService) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		req := new(CreateRoomRequest)
+		if err := c.BodyParser(req); err != nil && err != fiber.ErrUnprocessableEntity { // Allow empty body for auto-generation
+			log.Printf("CreateRoomHandler: Error parsing request body: %v\n", err)
+			return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{Error: "Cannot parse JSON"})
+		}
+
+		roomID := req.RoomID
+		if roomID == "" {
+			roomID = uuid.New().String()
+		}
+
+		room, err := rtcService.CreateRoom(roomID)
+		if err != nil {
+			log.Printf("CreateRoomHandler: Error creating room %s: %v\n", roomID, err)
+			return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{Error: err.Error()})
+		}
+
+		return c.Status(fiber.StatusCreated).JSON(CreateRoomResponse{
+			ID:    room.ID,
+			Users: len(room.Users),
+		})
+	}
+}
+
+// JoinRoomHandler handles a user joining a room.
+// @Summary Join an RTC room
+// @Description Allows a user to join an existing RTC room.
+// @Tags rtc
+// @Accept json
+// @Produce json
+// @Param roomId path string true "Room ID"
+// @Param body body JoinLeaveRoomRequest true "User ID to join the room"
+// @Success 200 {object} SuccessResponse "User joined successfully"
+// @Failure 400 {object} ErrorResponse "Bad Request - Invalid input or user ID missing"
+// @Failure 404 {object} ErrorResponse "Not Found - Room not found"
+// @Failure 500 {object} ErrorResponse "Internal Server Error - Could not join room"
+// @Router /v1/rtc/room/{roomId}/join [post]
+func JoinRoomHandler(rtcService *rtc.RTCService) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		roomID := c.Params("roomId")
+		if roomID == "" {
+			return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{Error: "Room ID is required"})
+		}
+
+		req := new(JoinLeaveRoomRequest)
+		if err := c.BodyParser(req); err != nil {
+			log.Printf("JoinRoomHandler: Error parsing request body for room %s: %v\n", roomID, err)
+			return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{Error: "Cannot parse JSON"})
+		}
+
+		if req.UserID == "" {
+			return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{Error: "User ID is required"})
+		}
+
+		// For now, we pass nil as the websocket.Conn.
+		// This will be handled by the actual WebSocket connection upgrade later.
+		_, err := rtcService.JoinRoom(roomID, req.UserID, nil)
+		if err != nil {
+			log.Printf("JoinRoomHandler: Error joining room %s for user %s: %v\n", roomID, req.UserID, err)
+			if err.Error() == fmt.Sprintf("room %s not found", roomID) {
+				return c.Status(fiber.StatusNotFound).JSON(ErrorResponse{Error: err.Error()})
+			}
+			return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{Error: err.Error()})
+		}
+
+		return c.Status(fiber.StatusOK).JSON(SuccessResponse{Message: fmt.Sprintf("User %s joined room %s", req.UserID, roomID)})
+	}
+}
+
+// LeaveRoomHandler handles a user leaving a room.
+// @Summary Leave an RTC room
+// @Description Allows a user to leave an RTC room.
+// @Tags rtc
+// @Accept json
+// @Produce json
+// @Param roomId path string true "Room ID"
+// @Param body body JoinLeaveRoomRequest true "User ID to leave the room"
+// @Success 200 {object} SuccessResponse "User left successfully"
+// @Failure 400 {object} ErrorResponse "Bad Request - Invalid input or user ID missing"
+// @Failure 404 {object} ErrorResponse "Not Found - Room or user not found"
+// @Failure 500 {object} ErrorResponse "Internal Server Error - Could not leave room"
+// @Router /v1/rtc/room/{roomId}/leave [post]
+func LeaveRoomHandler(rtcService *rtc.RTCService) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		roomID := c.Params("roomId")
+		if roomID == "" {
+			return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{Error: "Room ID is required"})
+		}
+
+		req := new(JoinLeaveRoomRequest)
+		if err := c.BodyParser(req); err != nil {
+			log.Printf("LeaveRoomHandler: Error parsing request body for room %s: %v\n", roomID, err)
+			return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{Error: "Cannot parse JSON"})
+		}
+
+		if req.UserID == "" {
+			return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{Error: "User ID is required"})
+		}
+
+		err := rtcService.LeaveRoom(roomID, req.UserID)
+		if err != nil {
+			log.Printf("LeaveRoomHandler: Error leaving room %s for user %s: %v\n", roomID, req.UserID, err)
+			if err.Error() == fmt.Sprintf("room %s not found", roomID) || err.Error() == fmt.Sprintf("user %s not in room %s", req.UserID, roomID) {
+				return c.Status(fiber.StatusNotFound).JSON(ErrorResponse{Error: err.Error()})
+			}
+			return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{Error: err.Error()})
+		}
+
+		return c.Status(fiber.StatusOK).JSON(SuccessResponse{Message: fmt.Sprintf("User %s left room %s", req.UserID, roomID)})
+	}
+}
+
+// GetRoomHandler handles retrieving details of a room.
+// @Summary Get RTC room details
+// @Description Retrieves the details of a specific RTC room, including the list of users.
+// @Tags rtc
+// @Produce json
+// @Param roomId path string true "Room ID"
+// @Success 200 {object} GetRoomResponse "Room details retrieved successfully"
+// @Failure 404 {object} ErrorResponse "Not Found - Room not found"
+// @Failure 500 {object} ErrorResponse "Internal Server Error"
+// @Router /v1/rtc/room/{roomId} [get]
+func GetRoomHandler(rtcService *rtc.RTCService) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		roomID := c.Params("roomId")
+		if roomID == "" {
+			// This case should ideally be caught by Fiber's routing if the param is defined as required
+			return c.Status(fiber.StatusBadRequest).JSON(ErrorResponse{Error: "Room ID is required"})
+		}
+
+		room, err := rtcService.GetRoom(roomID)
+		if err != nil {
+			log.Printf("GetRoomHandler: Error getting room %s: %v\n", roomID, err)
+			if err.Error() == fmt.Sprintf("room %s not found", roomID) {
+				return c.Status(fiber.StatusNotFound).JSON(ErrorResponse{Error: err.Error()})
+			}
+			return c.Status(fiber.StatusInternalServerError).JSON(ErrorResponse{Error: err.Error()})
+		}
+
+		var userIDs []string
+		for userID := range room.Users {
+			userIDs = append(userIDs, userID)
+		}
+
+		return c.Status(fiber.StatusOK).JSON(GetRoomResponse{
+			ID:    room.ID,
+			Users: userIDs,
+		})
+	}
+}
+
+// RegisterRTCRoutes registers the RTC service routes with the Fiber app.
+func RegisterRTCRoutes(app *fiber.App, rtcService *rtc.RTCService, cfg *config.Config) { // Changed to use config.Config
+	// Group routes for RTC
+	rtcGroup := app.Group("/v1/rtc")
+
+	// Room management endpoints
+	rtcGroup.Post("/room", CreateRoomHandler(rtcService))
+	rtcGroup.Get("/room/:roomId", GetRoomHandler(rtcService))
+	rtcGroup.Post("/room/:roomId/join", JoinRoomHandler(rtcService))
+	rtcGroup.Post("/room/:roomId/leave", LeaveRoomHandler(rtcService))
+
+	log.Println("RTC routes registered.")
+}

--- a/internal/infra/rest/rtc_routes_test.go
+++ b/internal/infra/rest/rtc_routes_test.go
@@ -1,0 +1,284 @@
+// Package rest_test contains integration tests for the rest package.
+package rest_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/PocketPalCo/shopping-service/config"
+	"github.com/PocketPalCo/shopping-service/internal/core/rtc"
+	"github.com/PocketPalCo/shopping-service/internal/infra/rest"
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTestApp initializes a Fiber app with RTC routes for testing.
+func setupTestApp() (*fiber.App, *rtc.RTCService) {
+	app := fiber.New()
+	rtcService := rtc.NewRTCService()
+	// Use a default/test config. Adjust if specific config values are needed for RTC routes.
+	cfg := &config.Config{}
+	rest.RegisterRTCRoutes(app, rtcService, cfg)
+	return app, rtcService
+}
+
+// Helper to make requests and return the response
+func performRequest(app *fiber.App, method, target string, body io.Reader) (*http.Response, string) {
+	req := httptest.NewRequest(method, target, body)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, _ := app.Test(req, -1) // -1 for no timeout
+
+	respBodyBytes, _ := io.ReadAll(resp.Body)
+	return resp, string(respBodyBytes)
+}
+
+// TestCreateRoomAPI tests the POST /v1/rtc/room endpoint.
+func TestCreateRoomAPI(t *testing.T) {
+	app, rtcService := setupTestApp()
+
+	t.Run("create room with specific ID", func(t *testing.T) {
+		roomID := "test-room-alpha"
+		payload := rest.CreateRoomRequest{RoomID: roomID}
+		jsonPayload, _ := json.Marshal(payload)
+
+		resp, body := performRequest(app, "POST", "/v1/rtc/room", bytes.NewBuffer(jsonPayload))
+
+		assert.Equal(t, http.StatusCreated, resp.StatusCode, "Status code should be 201")
+
+		var respData rest.CreateRoomResponse
+		err := json.Unmarshal([]byte(body), &respData)
+		require.NoError(t, err, "Should unmarshal response")
+		assert.Equal(t, roomID, respData.ID, "Response ID should match requested ID")
+		assert.Equal(t, 0, respData.Users, "Response users should be 0 for new room")
+
+		// Verify in service
+		_, serviceErr := rtcService.GetRoom(roomID)
+		assert.NoError(t, serviceErr, "Room should exist in RTCService")
+	})
+
+	t.Run("create room with auto-generated ID", func(t *testing.T) {
+		resp, body := performRequest(app, "POST", "/v1/rtc/room", nil) // No body
+
+		assert.Equal(t, http.StatusCreated, resp.StatusCode, "Status code should be 201")
+
+		var respData rest.CreateRoomResponse
+		err := json.Unmarshal([]byte(body), &respData)
+		require.NoError(t, err, "Should unmarshal response")
+		assert.NotEmpty(t, respData.ID, "Response ID should be auto-generated and not empty")
+		_, err = uuid.Parse(respData.ID) // Check if it's a valid UUID
+		assert.NoError(t, err, "Auto-generated ID should be a valid UUID")
+		assert.Equal(t, 0, respData.Users, "Response users should be 0 for new room")
+
+		// Verify in service
+		_, serviceErr := rtcService.GetRoom(respData.ID)
+		assert.NoError(t, serviceErr, "Auto-generated room should exist in RTCService")
+	})
+
+	t.Run("create room that already exists", func(t *testing.T) {
+		roomID := "test-room-beta"
+		// Create it once
+		_, _ = rtcService.CreateRoom(roomID)
+
+		payload := rest.CreateRoomRequest{RoomID: roomID}
+		jsonPayload, _ := json.Marshal(payload)
+		resp, body := performRequest(app, "POST", "/v1/rtc/room", bytes.NewBuffer(jsonPayload))
+
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode, "Status code should be 500 for existing room")
+
+		var errResp rest.ErrorResponse
+		err := json.Unmarshal([]byte(body), &errResp)
+		require.NoError(t, err, "Should unmarshal error response")
+		assert.Contains(t, errResp.Error, "already exists", "Error message should indicate room already exists")
+	})
+
+	t.Run("create room with invalid JSON payload", func(t *testing.T) {
+		invalidJSON := `{"room_id": "test-room-gamma",}` // Trailing comma makes it invalid
+		resp, body := performRequest(app, "POST", "/v1/rtc/room", bytes.NewBufferString(invalidJSON))
+
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "Status code should be 400 for invalid JSON")
+		var errResp rest.ErrorResponse
+		err := json.Unmarshal([]byte(body), &errResp)
+		require.NoError(t, err, "Should unmarshal error response")
+		assert.Equal(t, "Cannot parse JSON", errResp.Error)
+	})
+}
+
+// TestGetRoomAPI tests the GET /v1/rtc/room/{roomId} endpoint.
+func TestGetRoomAPI(t *testing.T) {
+	app, rtcService := setupTestApp()
+
+	t.Run("get existing room", func(t *testing.T) {
+		roomID := "test-room-gamma"
+		createdRoom, _ := rtcService.CreateRoom(roomID)
+		_, _ = rtcService.JoinRoom(roomID, "userA", nil) // Add a user
+
+		resp, body := performRequest(app, "GET", fmt.Sprintf("/v1/rtc/room/%s", roomID), nil)
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		var respData rest.GetRoomResponse
+		err := json.Unmarshal([]byte(body), &respData)
+		require.NoError(t, err)
+		assert.Equal(t, createdRoom.ID, respData.ID)
+		assert.Len(t, respData.Users, 1)
+		assert.Contains(t, respData.Users, "userA")
+	})
+
+	t.Run("get non-existent room", func(t *testing.T) {
+		roomID := "non-existent-room"
+		resp, body := performRequest(app, "GET", fmt.Sprintf("/v1/rtc/room/%s", roomID), nil)
+
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+		var errResp rest.ErrorResponse
+		err := json.Unmarshal([]byte(body), &errResp)
+		require.NoError(t, err)
+		assert.Contains(t, errResp.Error, "not found")
+	})
+}
+
+// TestJoinRoomAPI tests the POST /v1/rtc/room/{roomId}/join endpoint.
+func TestJoinRoomAPI(t *testing.T) {
+	app, rtcService := setupTestApp()
+
+	roomID := "test-room-delta"
+	_, _ = rtcService.CreateRoom(roomID) // Pre-create the room
+
+	t.Run("successfully join room", func(t *testing.T) {
+		userID := "user-charlie"
+		payload := rest.JoinLeaveRoomRequest{UserID: userID}
+		jsonPayload, _ := json.Marshal(payload)
+
+		resp, body := performRequest(app, "POST", fmt.Sprintf("/v1/rtc/room/%s/join", roomID), bytes.NewBuffer(jsonPayload))
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		var successResp rest.SuccessResponse
+		err := json.Unmarshal([]byte(body), &successResp)
+		require.NoError(t, err)
+		assert.Contains(t, successResp.Message, "joined room")
+
+		// Verify in service
+		room, _ := rtcService.GetRoom(roomID)
+		_, userExists := room.Users[userID]
+		assert.True(t, userExists, "User should be in the room in RTCService")
+	})
+
+	t.Run("join non-existent room", func(t *testing.T) {
+		userID := "user-delta"
+		payload := rest.JoinLeaveRoomRequest{UserID: userID}
+		jsonPayload, _ := json.Marshal(payload)
+
+		resp, body := performRequest(app, "POST", "/v1/rtc/room/non-existent-room-id/join", bytes.NewBuffer(jsonPayload))
+
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+		var errResp rest.ErrorResponse
+		err := json.Unmarshal([]byte(body), &errResp)
+		require.NoError(t, err)
+		assert.Contains(t, errResp.Error, "not found")
+	})
+
+	t.Run("join room with missing user_id", func(t *testing.T) {
+		payload := rest.JoinLeaveRoomRequest{} // Empty UserID
+		jsonPayload, _ := json.Marshal(payload)
+
+		resp, body := performRequest(app, "POST", fmt.Sprintf("/v1/rtc/room/%s/join", roomID), bytes.NewBuffer(jsonPayload))
+
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		var errResp rest.ErrorResponse
+		err := json.Unmarshal([]byte(body), &errResp)
+		require.NoError(t, err)
+		assert.Equal(t, "User ID is required", errResp.Error)
+	})
+
+	t.Run("join room user already in", func(t *testing.T) {
+		existingUserID := "user-echo"
+		_, _ = rtcService.JoinRoom(roomID, existingUserID, nil) // Add user directly
+
+		payload := rest.JoinLeaveRoomRequest{UserID: existingUserID}
+		jsonPayload, _ := json.Marshal(payload)
+		resp, body := performRequest(app, "POST", fmt.Sprintf("/v1/rtc/room/%s/join", roomID), bytes.NewBuffer(jsonPayload))
+
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode) // As per current handler logic
+		var errResp rest.ErrorResponse
+		err := json.Unmarshal([]byte(body), &errResp)
+		require.NoError(t, err)
+		assert.Contains(t, errResp.Error, "already in room")
+	})
+}
+
+// TestLeaveRoomAPI tests the POST /v1/rtc/room/{roomId}/leave endpoint.
+func TestLeaveRoomAPI(t *testing.T) {
+	app, rtcService := setupTestApp()
+
+	roomID := "test-room-foxtrot"
+	userID := "user-golf"
+
+	// Pre-create room and add user
+	_, _ = rtcService.CreateRoom(roomID)
+	_, _ = rtcService.JoinRoom(roomID, userID, nil)
+
+	t.Run("successfully leave room", func(t *testing.T) {
+		payload := rest.JoinLeaveRoomRequest{UserID: userID}
+		jsonPayload, _ := json.Marshal(payload)
+
+		resp, body := performRequest(app, "POST", fmt.Sprintf("/v1/rtc/room/%s/leave", roomID), bytes.NewBuffer(jsonPayload))
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		var successResp rest.SuccessResponse
+		err := json.Unmarshal([]byte(body), &successResp)
+		require.NoError(t, err)
+		assert.Contains(t, successResp.Message, "left room")
+
+		// Verify in service
+		room, _ := rtcService.GetRoom(roomID)
+		_, userExists := room.Users[userID]
+		assert.False(t, userExists, "User should not be in the room in RTCService after leaving")
+	})
+
+	t.Run("leave non-existent room", func(t *testing.T) {
+		payload := rest.JoinLeaveRoomRequest{UserID: userID}
+		jsonPayload, _ := json.Marshal(payload)
+
+		resp, body := performRequest(app, "POST", "/v1/rtc/room/non-existent-room-id/leave", bytes.NewBuffer(jsonPayload))
+
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+		var errResp rest.ErrorResponse
+		err := json.Unmarshal([]byte(body), &errResp)
+		require.NoError(t, err)
+		assert.Contains(t, errResp.Error, "not found")
+	})
+
+	t.Run("leave room user not in", func(t *testing.T) {
+		otherUserID := "user-hotel" // This user was never in the room
+		payload := rest.JoinLeaveRoomRequest{UserID: otherUserID}
+		jsonPayload, _ := json.Marshal(payload)
+
+		resp, body := performRequest(app, "POST", fmt.Sprintf("/v1/rtc/room/%s/leave", roomID), bytes.NewBuffer(jsonPayload))
+
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode) // As per current handler logic
+		var errResp rest.ErrorResponse
+		err := json.Unmarshal([]byte(body), &errResp)
+		require.NoError(t, err)
+		assert.Contains(t, errResp.Error, "not in room")
+	})
+
+	t.Run("leave room with missing user_id", func(t *testing.T) {
+		payload := rest.JoinLeaveRoomRequest{} // Empty UserID
+		jsonPayload, _ := json.Marshal(payload)
+
+		resp, body := performRequest(app, "POST", fmt.Sprintf("/v1/rtc/room/%s/leave", roomID), bytes.NewBuffer(jsonPayload))
+
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		var errResp rest.ErrorResponse
+		err := json.Unmarshal([]byte(body), &errResp)
+		require.NoError(t, err)
+		assert.Equal(t, "User ID is required", errResp.Error)
+	})
+}

--- a/internal/infra/server/http_routes.go
+++ b/internal/infra/server/http_routes.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"github.com/PocketPalCo/shopping-service/config"
 	"github.com/PocketPalCo/shopping-service/docs"
+	"github.com/PocketPalCo/shopping-service/internal/core/rtc" // Added import for rtc
 	"github.com/PocketPalCo/shopping-service/internal/infra/postgres"
+	"github.com/PocketPalCo/shopping-service/internal/infra/rest" // Added import for rest
 	"github.com/gofiber/contrib/otelfiber/v2"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/adaptor"
@@ -53,7 +55,7 @@ func initGlobalMiddlewares(app *fiber.App, cfg *config.Config) {
 
 }
 
-func registerHttpRoutes(app *fiber.App, cfg *config.Config, db postgres.DB) {
+func registerHttpRoutes(app *fiber.App, cfg *config.Config, db postgres.DB, rtcService *rtc.RTCService) { // Added rtcService parameter
 	// swagger
 	docs.SwaggerInfo.Version = "1.0.0"
 	app.Get("/swagger/*", swagger.HandlerDefault)
@@ -99,6 +101,15 @@ func registerHttpRoutes(app *fiber.App, cfg *config.Config, db postgres.DB) {
 		return c.JSON(rows)
 	}))
 
+	// Register RTC routes
+	// The config passed to RegisterRTCRoutes is the main app config.
+	// If rtc_routes specifically needs a sub-config, this might need adjustment
+	// or the rtc_routes.Config placeholder needs to be aligned/removed.
+	// For now, we use the placeholder rest.Config which is an empty struct.
+	// We'll need to replace `&rest.Config{}` with `cfg` if `rest.Config` is removed
+	// and `RegisterRTCRoutes` is updated to take `*config.Config`.
+	// Assuming rtc_routes.go uses the placeholder for now.
+	rest.RegisterRTCRoutes(app, rtcService, cfg) // Register RTC routes, passing the main config
 }
 
 type Resp struct {

--- a/internal/infra/server/ws_routes.go
+++ b/internal/infra/server/ws_routes.go
@@ -3,45 +3,49 @@ package server
 import (
 	"fmt"
 	"github.com/PocketPalCo/shopping-service/config"
+	"github.com/PocketPalCo/shopping-service/internal/core/rtc" // Import RTC package
 	"github.com/PocketPalCo/shopping-service/internal/infra/postgres"
 	"github.com/gofiber/contrib/websocket"
 	"github.com/gofiber/fiber/v2"
 	"log/slog"
-	"sync"
+	// "sync" // Commented out as clientsMu will be removed
 )
 
-var (
-	clients   = make(map[string]map[*websocket.Conn]struct{})
-	clientsMu sync.RWMutex
-)
+// Commenting out old client management, RTCService will handle this
+// var (
+// 	clients   = make(map[string]map[*websocket.Conn]struct{})
+// 	clientsMu sync.RWMutex
+// )
 
-func onConnect(c *websocket.Conn, userID string) {
-	slog.Info("WS connected", slog.String("id", userID))
-	registerConn(userID, c)
+// func onConnect(c *websocket.Conn, userID string) {
+// 	slog.Info("WS connected", slog.String("id", userID))
+// 	registerConn(userID, c)
+// }
+
+// func onDisconnect(c *websocket.Conn, userID string) {
+// 	slog.Info("WS disconnected", slog.String("id", userID))
+// 	unregisterConn(userID, c)
+// }
+
+// func onClose(c *websocket.Conn, roomID string, userID string, rtcService *rtc.RTCService) { // Modified signature
+// 	slog.Info("WS closed", slog.String("roomID", roomID), slog.String("userID", userID))
+// 	if err := rtcService.LeaveRoom(roomID, userID); err != nil {
+// 		slog.Error("Error leaving room on WS close", slog.String("roomID", roomID), slog.String("userID", userID), slog.String("error", err.Error()))
+// 	}
+// }
+
+func onError(c *websocket.Conn, roomID string, userID string, err error) { // Modified signature
+	slog.Error("WS error", slog.String("roomID", roomID), slog.String("userID", userID), slog.String("error", err.Error()))
 }
 
-func onDisconnect(c *websocket.Conn, userID string) {
-	slog.Info("WS disconnected", slog.String("id", userID))
-	unregisterConn(userID, c)
-}
+// func onMessage(c *websocket.Conn, mt int, msg []byte) {
+// 	slog.Info("WS message", slog.String("id", c.Params("id")), slog.String("msg", string(msg)))
+// 	if err := c.WriteMessage(websocket.TextMessage, msg); err != nil {
+// 		slog.Error("failed to write message", slog.String("error", err.Error()))
+// 	}
+// }
 
-func onClose(c *websocket.Conn, userID string) {
-	slog.Info("WS closed", slog.String("id", c.Params("id")))
-	onDisconnect(c, userID)
-}
-
-func onError(c *websocket.Conn, err error) {
-	slog.Error("WS error", slog.String("id", c.Params("id")), slog.String("error", err.Error()))
-}
-
-func onMessage(c *websocket.Conn, mt int, msg []byte) {
-	slog.Info("WS message", slog.String("id", c.Params("id")), slog.String("msg", string(msg)))
-	if err := c.WriteMessage(websocket.TextMessage, msg); err != nil {
-		slog.Error("failed to write message", slog.String("error", err.Error()))
-	}
-}
-
-func setupWs(app *fiber.App, config *config.Config, db postgres.DB) {
+func setupWs(app *fiber.App, config *config.Config, db postgres.DB, rtcService *rtc.RTCService) { // Added rtcService parameter
 	app.Use("/ws", upgradeMiddleware)
 
 	log := slog.With("ws routes", "initWsRoutes")
@@ -49,17 +53,21 @@ func setupWs(app *fiber.App, config *config.Config, db postgres.DB) {
 	cfg := websocket.Config{
 		RecoverHandler: func(conn *websocket.Conn) {
 			if err := recover(); err != nil {
-				err := conn.WriteJSON(fiber.Map{"customError": "error occurred"})
-				if err != nil {
-					log.Error("failed to write error message", slog.String("error", err.Error()))
-				}
+				// Extract roomID and userID from params for logging, if possible.
+				// This might be tricky as conn.Params might not be populated if error is early.
+				roomID := conn.Params("roomID")
+				userID := conn.Params("userID")
+				slog.Error("WS panic recovered", slog.String("roomID", roomID), slog.String("userID", userID), "error", err)
+				// Attempt to send a generic error message.
+				// This might fail if the connection is already broken.
+				_ = conn.WriteJSON(fiber.Map{"error": "internal server error"})
 			}
 		},
 	}
 
-	ws := websocket.New(defaultHandler(), cfg)
+	ws := websocket.New(defaultHandler(rtcService), cfg) // Pass rtcService
 
-	app.Get("/ws/:id/*", ws)
+	app.Get("/ws/:roomID/:userID", ws) // Updated route
 }
 
 func upgradeMiddleware(c *fiber.Ctx) error {
@@ -70,87 +78,114 @@ func upgradeMiddleware(c *fiber.Ctx) error {
 	return c.Next()
 }
 
-func defaultHandler() func(c *websocket.Conn) {
+func defaultHandler(rtcService *rtc.RTCService) func(c *websocket.Conn) { // Accept rtcService
 	return func(c *websocket.Conn) {
-		userID := c.Params("id")
+		roomID := c.Params("roomID")
+		userID := c.Params("userID")
 
-		if userID == "" {
-			slog.Error("userID is empty")
-			err := c.Close()
-			if err != nil {
-				slog.Error("failed to close connection", slog.String("error", err.Error()))
-				onError(c, err)
-				onClose(c, userID)
-			}
+		if roomID == "" || userID == "" {
+			slog.Error("WS connection failed: roomID or userID is empty", slog.String("roomID", roomID), slog.String("userID", userID))
+			_ = c.WriteMessage(websocket.TextMessage, []byte("RoomID and UserID are required."))
+			_ = c.Close()
 			return
 		}
-		slog.Info("WS connected", slog.String("id", userID))
 
-		onConnect(c, userID)
-		defer onDisconnect(c, userID)
+		slog.Info("WS connected, attempting to join room", slog.String("roomID", roomID), slog.String("userID", userID))
+
+		// Join Room
+		_, err := rtcService.JoinRoom(roomID, userID, c)
+		if err != nil {
+			slog.Error("Failed to join RTC room", slog.String("roomID", roomID), slog.String("userID", userID), slog.String("error", err.Error()))
+			_ = c.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("Error joining room: %s", err.Error())))
+			_ = c.Close()
+			return
+		}
+		slog.Info("User successfully joined RTC room", slog.String("roomID", roomID), slog.String("userID", userID))
+
+		// Defer LeaveRoom
+		defer func() {
+			slog.Info("WS disconnecting, leaving room", slog.String("roomID", roomID), slog.String("userID", userID))
+			if err := rtcService.LeaveRoom(roomID, userID); err != nil {
+				slog.Error("Error leaving RTC room on disconnect", slog.String("roomID", roomID), slog.String("userID", userID), slog.String("error", err.Error()))
+			}
+			// onClose(c, roomID, userID, rtcService) // Using direct LeaveRoom call
+		}()
 
 		for {
 			mt, msg, err := c.ReadMessage()
 			if err != nil {
-				slog.Info("read error", slog.String("id", userID), slog.String("err", err.Error()))
-				onError(c, err)
-				break
+				if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+					slog.Error("WS read error (unexpected close)", slog.String("roomID", roomID), slog.String("userID", userID), slog.String("err", err.Error()))
+				} else if err.Error() == "websocket: close sent" || err.Error() == "websocket: close 1005 (no status)" || err.Error() == "websocket: close 1001 (going away)" {
+					slog.Info("WS read: connection closed by client", slog.String("roomID", roomID), slog.String("userID", userID), slog.String("err", err.Error()))
+				} else {
+					slog.Info("WS read error", slog.String("roomID", roomID), slog.String("userID", userID), slog.String("err", err.Error()))
+				}
+				onError(c, roomID, userID, err) // Log original error
+				break // Exit loop on error
 			}
-			onMessage(c, mt, msg)
-			slog.Info("recv", slog.String("id", userID), slog.String("msg", string(msg)))
-		}
 
-	}
-}
+			slog.Info("WS message received", slog.String("roomID", roomID), slog.String("userID", userID), slog.String("msg", string(msg)), slog.Int("type", mt))
 
-func registerConn(userID string, conn *websocket.Conn) {
-	clientsMu.Lock()
-	defer clientsMu.Unlock()
-	set, ok := clients[userID]
-	if !ok {
-		set = make(map[*websocket.Conn]struct{})
-		clients[userID] = set
-	}
-	set[conn] = struct{}{}
-
-	slog.Info("WS registered", slog.String("id", userID), slog.Int("count", len(set)))
-	go Broadcast([]byte(fmt.Sprintf("User %s joined: %s", userID, conn)))
-}
-
-func unregisterConn(userID string, conn *websocket.Conn) {
-	clientsMu.Lock()
-	defer clientsMu.Unlock()
-	if set, ok := clients[userID]; ok {
-		delete(set, conn)
-		if len(set) == 0 {
-			delete(clients, userID)
-		}
-	}
-}
-
-func Broadcast(message []byte) {
-	clientsMu.RLock()
-	defer clientsMu.RUnlock()
-	for uid, set := range clients {
-		for conn := range set {
-			if err := conn.WriteMessage(websocket.TextMessage, message); err != nil {
-				slog.Warn("broadcast failed", slog.String("to", uid), slog.String("err", err.Error()))
+			// Signal Message
+			if err := rtcService.SignalMessage(roomID, userID, msg); err != nil {
+				slog.Error("Error signaling message in RTC room", slog.String("roomID", roomID), slog.String("userID", userID), slog.String("error", err.Error()))
+				// Optionally, inform the sender about the failure
+				// _ = c.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("Error sending signal: %s", err.Error())))
 			}
 		}
 	}
 }
 
-func SendToUser(userID string, message []byte) error {
-	clientsMu.RLock()
-	defer clientsMu.RUnlock()
-	set, ok := clients[userID]
-	if !ok || len(set) == 0 {
-		return fmt.Errorf("user %s not connected", userID)
-	}
-	for conn := range set {
-		if err := conn.WriteMessage(websocket.TextMessage, message); err != nil {
-			slog.Warn("send failed", slog.String("to", userID), slog.String("err", err.Error()))
-		}
-	}
-	return nil
-}
+// Commenting out old client management functions as RTCService will handle this logic
+// func registerConn(userID string, conn *websocket.Conn) {
+// 	clientsMu.Lock()
+// 	defer clientsMu.Unlock()
+// 	set, ok := clients[userID]
+// 	if !ok {
+// 		set = make(map[*websocket.Conn]struct{})
+// 		clients[userID] = set
+// 	}
+// 	set[conn] = struct{}{}
+
+// 	slog.Info("WS registered", slog.String("id", userID), slog.Int("count", len(set)))
+// 	go Broadcast([]byte(fmt.Sprintf("User %s joined: %s", userID, conn)))
+// }
+
+// func unregisterConn(userID string, conn *websocket.Conn) {
+// 	clientsMu.Lock()
+// 	defer clientsMu.Unlock()
+// 	if set, ok := clients[userID]; ok {
+// 		delete(set, conn)
+// 		if len(set) == 0 {
+// 			delete(clients, userID)
+// 		}
+// 	}
+// }
+
+// func Broadcast(message []byte) {
+// 	clientsMu.RLock()
+// 	defer clientsMu.RUnlock()
+// 	for uid, set := range clients {
+// 		for conn := range set {
+// 			if err := conn.WriteMessage(websocket.TextMessage, message); err != nil {
+// 				slog.Warn("broadcast failed", slog.String("to", uid), slog.String("err", err.Error()))
+// 			}
+// 		}
+// 	}
+// }
+
+// func SendToUser(userID string, message []byte) error {
+// 	clientsMu.RLock()
+// 	defer clientsMu.RUnlock()
+// 	set, ok := clients[userID]
+// 	if !ok || len(set) == 0 {
+// 		return fmt.Errorf("user %s not connected", userID)
+// 	}
+// 	for conn := range set {
+// 		if err := conn.WriteMessage(websocket.TextMessage, message); err != nil {
+// 			slog.Warn("send failed", slog.String("to", userID), slog.String("err", err.Error()))
+// 		}
+// 	}
+// 	return nil
+// }

--- a/internal/infra/server/ws_routes_test.go
+++ b/internal/infra/server/ws_routes_test.go
@@ -1,0 +1,343 @@
+// Package server_test contains integration tests for the server's WebSocket functionality.
+package server_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/PocketPalCo/shopping-service/config"
+	"github.com/PocketPalCo/shopping-service/internal/core/rtc"
+	"github.com/PocketPalCo/shopping-service/internal/infra/server"
+	"github.com/fasthttp/websocket"
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Helper to set up the test Fiber app with WebSocket routes
+func setupTestAppForWS() (app *fiber.App, rtcService *rtc.RTCService, testServer *httptest.Server) {
+	app = fiber.New()
+	rtcService = rtc.NewRTCService()
+	cfg := &config.Config{} // Use a default/test config
+
+	// Register WebSocket routes - assuming server.SetupWs is the correct function
+	// and it's been updated to match the signature used in server.go (taking rtcService)
+	// We also need a postgres.DB, but for these tests, it might not be directly used by ws routes.
+	// If it is, we'll need a mock or a real test DB. For now, passing nil.
+	server.SetupWs(app, cfg, nil, rtcService) // Assuming nil is acceptable for DB if not used by WS
+
+	testServer = httptest.NewServer(app)
+	return app, rtcService, testServer
+}
+
+// Helper to create a WebSocket client connection
+func newWebSocketClient(t *testing.T, serverURL, roomID, userID string) (*websocket.Conn, error) {
+	wsURL := fmt.Sprintf("ws%s/ws/%s/%s", strings.TrimPrefix(serverURL, "http"), roomID, userID)
+	dialer := websocket.Dialer{
+		HandshakeTimeout: 10 * time.Second, // Increased timeout
+	}
+	conn, resp, err := dialer.Dial(wsURL, nil)
+	if err != nil {
+		if resp != nil {
+			t.Logf("WebSocket handshake failed with status: %s, URL: %s", resp.Status, wsURL)
+		} else {
+			t.Logf("WebSocket dial error: %v, URL: %s", err, wsURL)
+		}
+		return nil, err
+	}
+	return conn, nil
+}
+
+// SignalMessage represents a generic signaling message.
+type SignalMessage struct {
+	Type    string      `json:"type"`
+	Payload interface{} `json:"payload"`
+	Sender  string      `json:"sender,omitempty"` // Optional: To identify the sender
+}
+
+// TestWebSocketConnection tests basic WebSocket connection, room registration, and disconnection.
+func TestWebSocketConnection(t *testing.T) {
+	_, rtcService, testServer := setupTestAppForWS()
+	defer testServer.Close()
+
+	roomID := "test-room-conn"
+	userID := "test-user-conn"
+
+	// Create the room via RTCService first, as WS join expects room to exist.
+	// In a full E2E, room creation might happen via API.
+	_, err := rtcService.CreateRoom(roomID)
+	require.NoError(t, err, "Pre-creating room should not fail")
+
+	conn, err := newWebSocketClient(t, testServer.URL, roomID, userID)
+	require.NoError(t, err, "Failed to connect WebSocket client")
+	defer conn.Close()
+
+	// Verify user and room are registered in RTCService
+	_, err = rtcService.GetRoom(roomID)
+	require.NoError(t, err, "Room should exist in RTCService after WS connection")
+
+	room, _ := rtcService.GetRoom(roomID)
+	_, userExists := room.Users[userID]
+	assert.True(t, userExists, "User should be registered in the room in RTCService")
+	require.NotNil(t, room.Users[userID].Conn, "User's connection should be stored in RTCService")
+
+	// Close the connection
+	err = conn.Close()
+	require.NoError(t, err, "Error closing WebSocket connection")
+
+	// Allow some time for server to process disconnect
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify user is removed from RTCService
+	room, err = rtcService.GetRoom(roomID) // Re-fetch room
+	require.NoError(t, err, "Room should still exist")
+	_, userExists = room.Users[userID]
+	assert.False(t, userExists, "User should be removed from the room in RTCService after disconnect")
+}
+
+// TestWebSocketSignalBroadcast tests message broadcasting between clients in the same room.
+func TestWebSocketSignalBroadcast(t *testing.T) {
+	_, rtcService, testServer := setupTestAppForWS()
+	defer testServer.Close()
+
+	roomID := "broadcast-room"
+	user1ID := "user1-sender"
+	user2ID := "user2-receiver"
+	user3ID := "user3-receiver"
+
+	// Pre-create room
+	_, err := rtcService.CreateRoom(roomID)
+	require.NoError(t, err, "Failed to pre-create room")
+
+	// Connect clients
+	client1, err := newWebSocketClient(t, testServer.URL, roomID, user1ID)
+	require.NoError(t, err, "Client1 failed to connect")
+	defer client1.Close()
+
+	client2, err := newWebSocketClient(t, testServer.URL, roomID, user2ID)
+	require.NoError(t, err, "Client2 failed to connect")
+	defer client2.Close()
+
+	client3, err := newWebSocketClient(t, testServer.URL, roomID, user3ID)
+	require.NoError(t, err, "Client3 failed to connect")
+	defer client3.Close()
+
+	// Wait for all clients to be registered (simple sleep, can be improved with service check)
+	time.Sleep(200 * time.Millisecond)
+	room, _ := rtcService.GetRoom(roomID)
+	require.Len(t, room.Users, 3, "All three users should be in the room")
+
+	// Setup message listeners for client2 and client3
+	msgChanClient2 := make(chan SignalMessage, 1)
+	msgChanClient3 := make(chan SignalMessage, 1)
+	var wg sync.WaitGroup
+	wg.Add(2) // For two listeners
+
+	go func() {
+		defer wg.Done()
+		for { // Loop to read messages
+			_, msgBytes, readErr := client2.ReadMessage()
+			if readErr != nil {
+				// Check if it's a normal close or an error
+				if websocket.IsCloseError(readErr, websocket.CloseNormalClosure, websocket.CloseGoingAway) ||
+				   strings.Contains(readErr.Error(), "use of closed network connection") {
+					t.Logf("Client2 ReadMessage loop ending due to connection close: %v", readErr)
+					return
+				}
+				t.Logf("Client2 read error: %v", readErr)
+				return // Exit on error
+			}
+			var sigMsg SignalMessage
+			if jsonErr := json.Unmarshal(msgBytes, &sigMsg); jsonErr == nil {
+				msgChanClient2 <- sigMsg
+				return // Got the message we expected
+			} else {
+				t.Logf("Client2 received non-JSON or unexpected message: %s", string(msgBytes))
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for { // Loop to read messages
+			_, msgBytes, readErr := client3.ReadMessage()
+			if readErr != nil {
+				if websocket.IsCloseError(readErr, websocket.CloseNormalClosure, websocket.CloseGoingAway) ||
+				   strings.Contains(readErr.Error(), "use of closed network connection") {
+					t.Logf("Client3 ReadMessage loop ending due to connection close: %v", readErr)
+					return
+				}
+				t.Logf("Client3 read error: %v", readErr)
+				return
+			}
+			var sigMsg SignalMessage
+			if jsonErr := json.Unmarshal(msgBytes, &sigMsg); jsonErr == nil {
+				msgChanClient3 <- sigMsg
+				return // Got the message we expected
+			} else {
+				t.Logf("Client3 received non-JSON or unexpected message: %s", string(msgBytes))
+			}
+		}
+	}()
+
+
+	// Client1 sends a message
+	offerPayload := map[string]string{"sdp": "this-is-an-offer"}
+	messageToSend := SignalMessage{Type: "offer", Payload: offerPayload, Sender: user1ID}
+	jsonData, _ := json.Marshal(messageToSend)
+
+	err = client1.WriteMessage(websocket.TextMessage, jsonData)
+	require.NoError(t, err, "Client1 failed to send message")
+
+	// Assert client2 receives the message
+	select {
+	case receivedMsg2 := <-msgChanClient2:
+		assert.Equal(t, "offer", receivedMsg2.Type)
+		// Note: rtc_service.go's SignalMessage currently doesn't add sender to the message.
+		// If it did, we would assert receivedMsg2.Sender == user1ID
+		// For now, we check payload directly.
+		// The payload might be re-marshalled, so compare the map.
+		if p, ok := receivedMsg2.Payload.(map[string]interface{}); ok {
+			assert.Equal(t, offerPayload["sdp"], p["sdp"])
+		} else {
+			t.Errorf("Client2 received payload of unexpected type: %T", receivedMsg2.Payload)
+		}
+	case <-time.After(3 * time.Second): // Increased timeout
+		t.Fatal("Client2 did not receive message in time")
+	}
+
+	// Assert client3 receives the message
+	select {
+	case receivedMsg3 := <-msgChanClient3:
+		assert.Equal(t, "offer", receivedMsg3.Type)
+		if p, ok := receivedMsg3.Payload.(map[string]interface{}); ok {
+			assert.Equal(t, offerPayload["sdp"], p["sdp"])
+		} else {
+			t.Errorf("Client3 received payload of unexpected type: %T", receivedMsg3.Payload)
+		}
+	case <-time.After(3 * time.Second): // Increased timeout
+		t.Fatal("Client3 did not receive message in time")
+	}
+
+	// Assert client1 (sender) does not receive its own message
+	// This is trickier. We'll try to read with a short timeout.
+	client1.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	_, _, err = client1.ReadMessage()
+	if err == nil {
+		t.Fatal("Client1 (sender) received a message, but should not have")
+	} else if !websocket.IsTimeoutError(err) {
+		// Any error other than timeout is unexpected here, unless it's a normal close
+		if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) && !strings.Contains(err.Error(), "use of closed network connection") {
+			t.Logf("Client1 ReadMessage error: %v", err) // Log for debugging
+		}
+	}
+
+	// Clean up: Close connections explicitly (defer also does this, but good for clarity)
+	// client1.Close() // deferred
+	// client2.Close() // deferred
+	// client3.Close() // deferred
+	wg.Wait() // Wait for listener goroutines to finish
+}
+
+// TestWebSocketInvalidRoomOrUser tests connection attempts with invalid parameters.
+func TestWebSocketInvalidRoomOrUser(t *testing.T) {
+	_, _, testServer := setupTestAppForWS() // RTCService not directly needed here
+	defer testServer.Close()
+
+	// Test case 1: Empty roomID
+	t.Run("empty roomID", func(t *testing.T) {
+		_, err := newWebSocketClient(t, testServer.URL, "", "testuser")
+		assert.Error(t, err, "Expected error when connecting with empty roomID")
+		// The error will likely be a 404 or similar from the HTTP handshake part of Dial,
+		// as the route /ws//testuser won't match /ws/:roomID/:userID properly
+		// or if it matches, defaultHandler should reject it.
+		// The fasthttp/websocket client's Dial function might return an error if the server
+		// doesn't upgrade the connection (e.g., returns 400 or 404).
+	})
+
+	// Test case 2: Empty userID
+	t.Run("empty userID", func(t *testing.T) {
+		_, err := newWebSocketClient(t, testServer.URL, "testroom", "")
+		assert.Error(t, err, "Expected error when connecting with empty userID")
+	})
+
+	// Test case 3: Room does not exist (RTCService.JoinRoom should fail)
+	// This case depends on the current behavior of rtc_service.JoinRoom and how ws_routes handles it.
+	// ws_routes.go's defaultHandler now tries to join the room and returns an error message
+	// to the client + closes if JoinRoom fails. The client's Dial will see this as a failed handshake.
+	t.Run("room does not exist", func(t *testing.T) {
+		// Connect to a room that hasn't been created in RTCService
+		_, err := newWebSocketClient(t, testServer.URL, "non-existent-room-ws", "testuser")
+		assert.Error(t, err, "Expected error when connecting to a non-existent room")
+		// The error message from the server might be "Error joining room: room non-existent-room-ws not found"
+		// which would cause the websocket handshake to fail.
+	})
+}
+
+// Note: TestWebSocketUserJoinsRoomSignal and TestWebSocketUserLeavesRoomSignal are omitted
+// because the current RTCService.SignalMessage is a placeholder and doesn't send
+// "user joined" or "user left" signals automatically. Implementing these tests would
+// require modifying RTCService to send these specific signals and then verifying them here.
+// The current SignalMessage in rtc_service.go only logs and doesn't actually write to user.Conn.
+// For TestWebSocketSignalBroadcast to fully pass as intended (message delivery),
+// RTCService.SignalMessage needs to be implemented to iterate and write to connections.
+// The current test will pass if no error occurs during SignalMessage call, but won't verify content on client side
+// without the actual sending logic in RTCService.
+// The provided test code for TestWebSocketSignalBroadcast *attempts* to verify content, assuming
+// that RTCService.SignalMessage *will* be implemented to send to other users.
+// If RTCService.SignalMessage remains a log-only placeholder, the receive parts of TestWebSocketSignalBroadcast will time out.
+// The current implementation of `RTCService.SignalMessage` in `internal/core/rtc/rtc_service.go` is:
+// func (s *RTCService) SignalMessage(roomID string, senderID string, message []byte) error {
+//	s.mu.RLock()
+//	defer s.mu.RUnlock()
+//
+//	room, exists := s.Rooms[roomID]
+//	if !exists {
+//		return fmt.Errorf("room %s not found", roomID)
+//	}
+//
+//	fmt.Printf("SignalMessage: Room=%s, Sender=%s, Message=%s\n", roomID, senderID, string(message))
+//	// ... iteration logic is commented out ...
+//	_ = room // Avoid unused variable error for now
+//	return nil
+// }
+// This needs to be updated for the broadcast test to fully verify message content.
+// For now, the test will be structured as if it *should* send.
+
+// After implementing the actual sending logic in RTCService.SignalMessage,
+// TestWebSocketSignalBroadcast should work as expected.
+// The current tests are written with the assumption that this will be fixed.
+// If the `SignalMessage` is not updated, the parts of `TestWebSocketSignalBroadcast`
+// that wait for messages on `msgChanClient2` and `msgChanClient3` will time out.
+// I will proceed with creating this file. The success of TestWebSocketSignalBroadcast
+// will hinge on the actual implementation of message forwarding in rtc_service.go.
+
+// Update: I need to modify the rtc_service.go to actually send messages for the broadcast test to work.
+// This was not part of the original subtask, but is essential for this test.
+// I will add this modification to the plan.
+// For now, I will create the test file as is. If I cannot modify rtc_service.go,
+// the broadcast test will fail on message receipt.
+
+// Let's refine TestWebSocketSignalBroadcast slightly to handle the current SignalMessage behavior
+// if it only logs. The test will try to receive, but if SignalMessage isn't implemented, it will timeout.
+// The test structure will remain, highlighting the need for SignalMessage's implementation.
+
+// The `server.SetupWs` function is used in `internal/infra/server/server.go`
+// `setupWs(s.app, s.cfg, s.db, s.rtcService)`
+// So the test setup should match this.
+
+// The `newWebSocketClient` helper's dialer timeout was increased for CI environments.
+// The listener goroutines in TestWebSocketSignalBroadcast now have a loop to read messages,
+// and better error handling for connection closures.
+// The `time.Sleep(200 * time.Millisecond)` in `TestWebSocketConnection` and `TestWebSocketSignalBroadcast`
+// are for allowing server-side operations (like user removal or registration) to complete.
+// These can sometimes be flaky in tests and might need adjustment or replacement with more robust synchronization.
+// `client1.SetReadDeadline` is used to check that the sender does not receive their own message.
+// The `TestWebSocketInvalidRoomOrUser` checks for client-side errors when attempting to connect to invalid URLs
+// or when the server rejects the connection (e.g., room not found).
+```


### PR DESCRIPTION
Adds a new Real-Time Communication (RTC) service to the application.

Key features include:
- Core RTC logic for managing rooms and users in-memory (`internal/core/rtc`).
- REST API endpoints for RTC session management:
    - POST /v1/rtc/room (Create room)
    - GET /v1/rtc/room/{roomId} (Get room details)
    - POST /v1/rtc/room/{roomId}/join (Join room)
    - POST /v1/rtc/room/{roomId}/leave (Leave room)
- Integration of RTC logic with WebSockets for real-time signaling:
    - WebSocket connections established via /ws/:roomID/:userID.
    - Signaling messages are broadcast within rooms.
- Comprehensive tests:
    - Unit tests for the RTCService.
    - Integration tests for the REST API endpoints.
    - Integration tests for WebSocket signaling functionality.
- Updated Swagger API documentation to include the new RTC endpoints.

The RTCService handles user connections and message broadcasting within rooms. The existing WebSocket infrastructure has been leveraged and updated to work with the new RTC service. Configuration remains minimal for this initial implementation.