### PR TITLE
Add DbConnectionString unit test

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,20 @@
+package config
+
+import "testing"
+
+func TestDbConnectionString(t *testing.T) {
+	cfg := Config{
+		DbUser:         "testuser",
+		DbPassword:     "p@ss word",
+		DbHost:         "localhost",
+		DbPort:         5432,
+		DbDatabaseName: "testdb",
+		DbSSLMode:      "disable",
+	}
+
+	expected := "postgresql://testuser:p%40ss+word@localhost:5432/testdb?sslmode=disable"
+
+	if got := cfg.DbConnectionString(); got != expected {
+		t.Errorf("DbConnectionString() = %q, want %q", got, expected)
+	}
+}


### PR DESCRIPTION
## Summary
- add `config/config_test.go` with a unit test for `DbConnectionString`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840403cf9d88330a16d0f05b2418c45