### PR TITLE
Fix Fiber body limit constant

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -159,7 +159,7 @@ func (c Config) Fiber() fiber.Config {
 	// Return Fiber configuration.
 	return fiber.Config{
 		ReadTimeout: time.Second * time.Duration(c.ServerReadTimeout),
-		BodyLimit:   10 * 1024 * 1024 * 1024, // 10MB
+		BodyLimit:   10 * 1024 * 1024, // 10MB
 	}
 }
 


### PR DESCRIPTION
## Summary
- correct the Fiber BodyLimit value to 10MB instead of 10GB

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6840402e6d7c8330a2409334a9f294ed